### PR TITLE
Remove duplicative macOS runner from CI and add back in Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest", "macos-latest", "macos-14", "windows-latest"]
-        python-version: [ "3.9", "3.11", "3.12" ]
+        os: [ "ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
     steps:
       - name: checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## PR Summary
Remove duplicative macOS runner from CI and add back in Python 3.10.

Closes #235

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. If an entire section doesn't
apply to this PR, comment it out or delete it. -->
**General**
- [ ] Make an issue if one doesn't already exist
- [ ] Link the issue this PR resolves by adding `closes #XXX` to the PR description where XXX is the number of the issue.
- [ ] Add a brief summary of changes to `docs/release-notes.rst` in a relevant section for the next unreleased release. Possible sections include: Documentation, New Features, Bug Fixes, Internal Changes, Breaking Changes/Deprecated
- [ ] Add appropriate labels to this PR
- [ ] Make your changes in a forked repository rather than directly in this repo
- [ ] Open this PR as a draft if it is not ready for review
- [ ] Convert this PR from a draft to a full PR before requesting reviewers
- [ ] Passes `precommit`. To set up on your local, run `pre-commit install` from the top level of the repository. To manually run pre-commits, use `pre-commit run --all-files` and re-add any changed files before committing again and pushing.